### PR TITLE
Fix Windows "." not found bug, Fix listening pattern for ".exe" files

### DIFF
--- a/codemon/codemon.py
+++ b/codemon/codemon.py
@@ -71,7 +71,7 @@ def isModified(event):
 		os.system('g++ ' + filename + ' -o ' + 'prog')
 		print('Running')	
 		print(colored.yellow('Taking inputs from input.txt'))
-		os.system('./prog < input.txt')
+		os.system(f'{os.getcwd()}/prog < input.txt')
 	
 def listen():
 	print(colored.yellow("Getting files in directory"))
@@ -79,8 +79,8 @@ def listen():
 	dircontents = os.listdir(path)
 	if len(dircontents) != 0: 
 		print(colored.magenta("Currently listening for file changes"))
-		patterns = "*"
-		ignore_patterns = ""
+		patterns = ['*']
+		ignore_patterns = ['prog', '*.exe']
 		ignore_directories = False
 		case_sensitive = True
 		event_handler = PatternMatchingEventHandler(patterns, ignore_patterns, ignore_directories, case_sensitive)
@@ -107,7 +107,7 @@ def main():
 			if arg == "init": 
 				if sys.argv[countArg] == '-n':
 					file = sys.argv[countArg+1]
-					path = '.'
+					path = os.getcwd()
 					f = open(path + '/' + file + '.cpp',"w+")
 					f.write(template)
 					f.close()


### PR DESCRIPTION
Closes #21: **Not working on windows platform with cmd**.

Modifications made:
- `.` can't be used to traverse the Windows file-system, so I implemented the standard OS-agnostic technique of accessing the file(s) in Python, using the `os` module and getting the current working directory using `os.getcwd()`. That indeed is the recommended way of accessing files in the current directory.
  ``` py
  f'{os.getcwd()}/prog' # Works in all environments
  ```
- I modified the patterns being used by `watchdog` to ensure the compiled binary isn't being watched. MSYS2 also uses `.exe` for compiled binaries, so we must ignore `*.exe` for Codemon to work successfully in any Windows environment.
  ``` py
  ...
  patterns = ['*']
  ignore_patterns = ['prog', '*.exe'] # Ignores Windows executables
  ...
  ```