### PR TITLE
Stop execution in case of a compilation error.

### DIFF
--- a/codemon/codemon.py
+++ b/codemon/codemon.py
@@ -68,10 +68,12 @@ def isModified(event):
 	if filename != foldername and filename != "prog" and filename != "input.txt": 
 		print(colored.yellow('\nChange made at '+ filename))
 		print(colored.cyan('\nCompiling '+ filename))
-		os.system('g++ ' + filename + ' -o ' + 'prog')
-		print('Running')	
-		print(colored.yellow('Taking inputs from input.txt'))
-		os.system('./prog < input.txt')
+		if os.system('g++ ' + filename + ' -o ' + 'prog') == 0:
+			print('Running')	
+			print(colored.yellow('Taking inputs from input.txt'))
+			os.system('./prog < input.txt')
+		else:
+			pass
 	
 def listen():
 	print(colored.yellow("Getting files in directory"))


### PR DESCRIPTION
Closes #25  Errors can be identified by checking output from `os.system`. Added a simple if/else that checks `os.system` output. If it is not zero, codemon will not execute `prog` . 