### PR TITLE
Migrate from os.system to subprocess.Popen

### DIFF
--- a/codemon/CodemonHelp.py
+++ b/codemon/CodemonHelp.py
@@ -1,13 +1,11 @@
 from clint.textui import colored
-import os
 
 def showHelp():
-  print(colored.green("           ---CODEMON---          "))
-  print("A CLI tool to ace competitive programming contests")
-  print(colored.cyan("\nCOMMANDS: \n"))
-  print("codemon - - - - - - - - - - - - - - -  shows help")
-  print("codemon --help - - - - - - - - - - - - shows help")
-  print("codemon init <contestName> - - - - - - initialises a contest")
-  print("codemon init -n <file> - - - - - - - - creates file with given name")
-  print("codemon listen - - - - - - - - - - - - compiles and gives output")
-  print("codemon practice <dirName> - - - - - - Starts a practice session")
+  print("           ---CODEMON---          ")
+  print(colored.cyan("  a CLI tool for competitive coders"))
+  print("\nCOMMANDS: \n")
+  print("codemon - - - - - - - - - - - - - - - shows help")
+  print("codemon init <contestName>  - - - - - initialises a contest")
+  print("codemon init -n <file>  - - - - - - - creates file with given name")
+  print("codemon listen  - - - - - - - - - - - compiles and gives output")
+  print("codemon practice <dirName>  - - - - - starts a practice session")

--- a/codemon/CodemonInit.py
+++ b/codemon/CodemonInit.py
@@ -1,24 +1,19 @@
 import os
 from clint.textui import colored
-from codemon.CodemonMeta import template_cpp
+from codemon.CodemonMeta import template_cpp, write_to_file
 
 def init(contestName,fileNames):
   # create a directory with contest name
   try:
     print(colored.green('Make some files and folders for ' + colored.magenta(contestName)))
-    path = os.getcwd()
-    os.mkdir(path + '/' + contestName)
-  except OSError:
-    print("Failed! This directory already exists.")
+    os.makedirs(os.path.join(os.getcwd(), contestName))
+  except OSError: 
+    print("Failed! This directory cannot be created.")
   else:
     print(colored.yellow('Directory is made'))
-    # create files for contest (should be 6 cpp files)
+      # create files for contest (should be 6 cpp files)
     for files in range(len(fileNames)):
-      f = open(path + '/' + contestName + '/' + fileNames[files],"w+")
-      template = template_cpp()
-      f.write(template)
-      f.close()
+      write_to_file(fileNames[files], template_cpp(), contestName)
     # create input file
-    f = open(path + '/' + contestName + '/' + "input.txt","w+")
-    f.close()
+    write_to_file('input.txt', '', contestName)
     print(colored.cyan('Files have been created'))

--- a/codemon/CodemonListen.py
+++ b/codemon/CodemonListen.py
@@ -4,17 +4,17 @@ import time
 from clint.textui import colored
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
+from codemon.CodemonMeta import compile_and_run
 
 def listen():
   print(colored.yellow("Getting files in directory"))
   path = os.getcwd()
   dircontents = os.listdir(path)
-
-  if len(dircontents) != 0:
+  if len(dircontents) != 0: 
     print(colored.magenta("Currently listening for file changes"))
-    patterns = "*"
-    ignore_patterns = ['prog', '*.exe']
-    ignore_directories = False
+    patterns = ['*.cpp']
+    ignore_patterns = ['prog', '*.exe', '*.swp']
+    ignore_directories = True
     case_sensitive = True
     event_handler = PatternMatchingEventHandler(patterns, ignore_patterns, ignore_directories, case_sensitive)
     event_handler.on_modified = isModified 
@@ -25,11 +25,10 @@ def listen():
       while True:
         time.sleep(1)
     except KeyboardInterrupt:
-        observer.stop()
-        observer.join()
-	
+      observer.stop()
+    observer.join()
   else:
-    print(colored.red("No files exist, check filename/path"))
+    print(colored.red("No files exist, check filename/path."))
 
 
 def isModified(event):
@@ -38,7 +37,4 @@ def isModified(event):
   if filename != foldername and filename != "prog" and filename != "input.txt": 
     print(colored.yellow('\nChange made at '+ filename))
     print(colored.cyan('\nCompiling '+ filename))
-    if os.system('g++ ' + filename + ' -o ' + 'prog') == 0:
-        print('Running')	
-        print(colored.yellow('Taking inputs from input.txt'))
-        os.system(f'{os.getcwd()}/prog < input.txt')
+    compile_and_run(filename)

--- a/codemon/CodemonMeta.py
+++ b/codemon/CodemonMeta.py
@@ -1,5 +1,9 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+from clint.textui import colored
 from datetime import datetime
-
 
 def template_cpp():
   # get the current time
@@ -9,14 +13,14 @@ def template_cpp():
   author: @ankingcodes
   created: %s
 */
-#include<bits/stdc++.h>
-#include<algorithm>
+#include <bits/stdc++.h>
+#include <algorithm>
 using namespace std;
 
 #define ll long long
 #define MOD 1000000000
 
-int main(){
+int main() {
   ios_base::sync_with_stdio(false);
   cin.tie(NULL);
   ll t;
@@ -27,10 +31,60 @@ int main(){
   return template
 
 
-def get_filename():
+def get_filenames():
   fileNames = ['A.cpp','B.cpp','C.cpp','D.cpp','E.cpp','F.cpp']
   return fileNames
 
 def get_practice_files():
   practiceFiles = ['A.cpp','B.cpp','C.cpp']
   return practiceFiles
+
+def write_to_file(filename, text, contestName=None):
+  full_filename = os.path.join(os.getcwd(), filename)
+  if contestName is not None:
+    full_filename = os.path.join(os.getcwd(), contestName, filename)
+  with open(full_filename, 'w+') as f:
+    f.write(text)
+
+def compile_and_run(filename):
+  # Store full file paths
+  full_filename = os.path.join(os.getcwd(), filename)
+  full_output_filename = os.path.join(os.getcwd(), 'prog')
+  full_input_filename = os.path.join(os.getcwd(), 'input.txt')
+
+  # Check if required files exist
+  if not Path(full_filename).is_file():
+    print(f"{filename} doesn't exist.", file=sys.stderr)
+  if not Path(full_input_filename).is_file():
+    print(f"'input.txt' doesn't exist.", file=sys.stderr)
+
+  compilation_child_process = subprocess.Popen(['g++', full_filename, '-o', full_output_filename], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+  compilation_child_process.wait()
+  compilation_child_process.terminate()
+  if compilation_child_process.returncode != 0:
+    return_code = compilation_child_process.returncode
+    if return_code == 127:
+      print("'g++' isn't installed.", file=sys.stderr)
+    else:
+      print('Error in compilation.', file=sys.stderr)
+      print(f'Return code: {return_code}', file=sys.stderr)
+    return
+  print('Running...')
+  execution_child_process = subprocess.Popen([full_output_filename], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+  input_text = ''
+  with open(full_input_filename, 'r', encoding='utf-8') as infile:
+    input_text = infile.read()
+  if len(input_text) > 0 and not input_text.isspace():
+    print(colored.yellow('Taking input from input.txt.'))
+    execution_child_process.stdin.write(input_text.encode(encoding='utf-8'))
+    execution_child_process.stdin.close()
+  else:
+    print(colored.yellow('input.txt is empty.\nSkipping input.'))
+  output = execution_child_process.communicate()
+  if len(output) > 0:
+    print(colored.green(output[0].decode()))
+    print()
+  else:
+    print(colored.red('No output.'))
+  execution_child_process.terminate()
+  print(f'Programme returned {execution_child_process.returncode}.')

--- a/codemon/codemon.py
+++ b/codemon/codemon.py
@@ -1,13 +1,14 @@
-#!/usr/local/bin
+#!/usr/bin/python3
 import sys
 import os
 from clint.textui import colored
 from codemon.CodemonHelp import showHelp
 from codemon.CodemonListen import listen
 from codemon.CodemonInit import init
-from codemon.CodemonMeta import template_cpp,get_filename,get_practice_files
+from codemon.CodemonMeta import template_cpp,get_filenames,get_practice_files
 
 def main():
+
   if len(sys.argv) < 2:
     showHelp()
 
@@ -17,6 +18,7 @@ def main():
       countArg+=1
 
       if arg == "init":
+
         if sys.argv[countArg] == '-n':
           file = sys.argv[countArg+1]
           path = '.'
@@ -29,7 +31,7 @@ def main():
 
         else:
           contestName = sys.argv[countArg]
-          fileNames = get_filename()
+          fileNames = get_filenames()
           init(contestName, fileNames)
 
       elif arg == "listen":
@@ -39,7 +41,3 @@ def main():
         contestName = sys.argv[countArg]
         practiceFiles = get_practice_files()
         init(contestName, practiceFiles)
-
-      elif arg == "--help":
-        showHelp()
-        break


### PR DESCRIPTION
Closes #33: **Migration to "subprocess" for executing commands**

Improvements:
- Uses `subprocess.Popen` instead of `os.system` for compilation and execution statements.
- In each of the child processes created, the flow of `stdin` and `stdout` are controlled i. e. Both are set in `subprocess.PIPE` and manually controlled using `obj.stdin` and `obj.communicate()`.
- Converted all file paths into OS-agnostic paths using `os.path.join`. The use of '/' as a separator might cause unexpected issues in several systems; `os.path` takes care of that.

The problem mentioned in #31 caused by whitespaces in the directory/file names is no longer a problem after the use of `subprocess`. The arguments are passed as an array to `subprocess.Popen`, which takes care of escaping the characters in an OS-agnostic way to avoid any possible error:
``` py]
...
obj = subprocess.Popen(['g++', full_filename, '-o', full_output_filename], 
                stdin=subprocess.PIPE, stdout=subprocess.PIPE)
...
```

The changes have been tested and Codemon successfully works in both GNU/UNIX-like (MSYS2, `bash`, WSL2, `xterm`) Windows (`cmd.exe`, PowerShell) environments.