### PR TITLE
Remove extra help command

### DIFF
--- a/codemon/CodemonHelp.py
+++ b/codemon/CodemonHelp.py
@@ -5,6 +5,7 @@ def showHelp():
   print(colored.green("           ---CODEMON---          "))
   print("A CLI tool to ace competitive programming contests")
   print(colored.cyan("\nCOMMANDS: \n"))
+  print("codemon - - - - - - - - - - - - - - -  displays this message")
   print("codemon --help - - - - - - - - - - - - shows help")
   print("codemon init <contestName> - - - - - - initialises a contest")
   print("codemon init -n <file> - - - - - - - - creates file with given name")

--- a/codemon/CodemonHelp.py
+++ b/codemon/CodemonHelp.py
@@ -5,7 +5,6 @@ def showHelp():
   print(colored.green("           ---CODEMON---          "))
   print("A CLI tool to ace competitive programming contests")
   print(colored.cyan("\nCOMMANDS: \n"))
-  print("codemon - - - - - - - - - - - - - - -  shows help")
   print("codemon --help - - - - - - - - - - - - shows help")
   print("codemon init <contestName> - - - - - - initialises a contest")
   print("codemon init -n <file> - - - - - - - - creates file with given name")


### PR DESCRIPTION
Since codemon now uses --help flag to show help, in my opinion, it's of no use to have the repetitive  "shows help". @ankingcodes  Please validate if you find this useful 