### PR TITLE
Codemon Fetch

### DIFF
--- a/codemon/CodemonFetch.py
+++ b/codemon/CodemonFetch.py
@@ -1,0 +1,52 @@
+import requests
+import os
+from bs4 import BeautifulSoup as beSo
+import itertools
+from clint.textui import colored
+
+def make_structure(name):
+  basedir = os.getcwd()
+
+  # Check if the question folder exists for the name passed if not make it.
+  if not  os.path.exists(os.path.join(basedir, f'{name}')):
+    os.makedirs(os.path.join(basedir, f'{name}'))
+
+  # Check if input file exists for the given name if not make it. 
+  if not  os.path.exists(os.path.join(basedir, os.path.join(f'{name}',f'{name}.in'))):
+    open(os.path.join(f'{name}',f'{name}.in'), 'w').close()
+
+  # Check if output file exists for the given name if not make it. 
+  if not  os.path.exists(os.path.join(basedir, os.path.join(f'{name}', f'{name}.out'))):
+    open(os.path.join(f'{name}', f'{name}.out'), 'w').close()
+
+
+def fetch_tests(contest_name):
+  try:
+    load_page = requests.get(f"https://codeforces.com/contest/{contest_name}/problems")
+    soup = beSo(load_page.content, 'html.parser')
+    tests = soup.findAll("div", attrs={"class":"sample-tests"})
+    name_list = ['A', 'B', 'C', 'D', 'E', 'F']
+
+    for file_name, test in zip(name_list, tests):
+      # Make the neccesary folders and files for each source file if not present.
+      make_structure(file_name)
+
+      # Add  inputs to .in files
+      for t in test.findAll("div", attrs={"class":"input"}):
+        i = t.pre.text
+        with open(os.path.join(f'{file_name}' , f'{file_name}.in'), 'a') as f:
+          f.write(i)
+
+      # Add outputs to .out files
+      for t in test.findAll("div", attrs={"class":"output"}):
+        o = t.pre.text
+        with open(os.path.join(f'{file_name}' , f'{file_name}.out'), 'a') as f:
+          f.write(o)
+
+  # In case of any error with scraping, display warning.
+  except:
+    print(colored.red("There was some error fetching the tests !!"))
+
+
+
+

--- a/codemon/CodemonFetch.py
+++ b/codemon/CodemonFetch.py
@@ -27,23 +27,29 @@ def fetch_tests(contest_name):
     load_page = requests.get(f"https://codeforces.com/contest/{contest_name}/problems")
     soup = beSo(load_page.content, 'html.parser')
     tests = soup.findAll("div", attrs={"class":"sample-tests"})
-    file_list = list(map(lambda x: x.split('.')[0], get_filename(contest_name)))
-    for file_name, test in tqdm(zip(file_list, tests), unit="ticks", desc="Fetching Sample test cases", 
-                                total=len(tests)):
-      # Make the neccesary folders and files for each source file if not present.
-      make_structure(file_name)
 
-      # Add  inputs to .in files
-      for t in test.findAll("div", attrs={"class":"input"}):
-        i = t.pre.text
-        with open(os.path.join(f'{file_name}' , f'{file_name}.in'), 'a') as f:
-          f.write(i)
+    if(len(tests) == 0):
+      print(colored.red("Wrong contest number provided"))
 
-      # Add outputs to .op files
-      for t in test.findAll("div", attrs={"class":"output"}):
-        o = t.pre.text
-        with open(os.path.join(f'{file_name}' , f'{file_name}.op'), 'a') as f:
-          f.write(o)
+    else:
+      # Get the file names to scrape test cases for.
+      file_list = list(map(lambda x: x.split('.')[0], get_filename(contest_name)))
+      for file_name, test in tqdm(zip(file_list, tests), unit="ticks", desc="Fetching Sample test cases", 
+                                  total=len(tests)):
+        # Make the neccesary folders and files for each source file if not present.
+        make_structure(file_name)
+
+        # Add  inputs to .in files
+        for t in test.findAll("div", attrs={"class":"input"}):
+          i = t.pre.text
+          with open(os.path.join(f'{file_name}' , f'{file_name}.in'), 'a') as f:
+            f.write(i)
+
+        # Add outputs to .op files
+        for t in test.findAll("div", attrs={"class":"output"}):
+          o = t.pre.text
+          with open(os.path.join(f'{file_name}' , f'{file_name}.op'), 'a') as f:
+            f.write(o)
 
   # In case of any error with scraping, display warning.
   except:

--- a/codemon/CodemonFetch.py
+++ b/codemon/CodemonFetch.py
@@ -18,8 +18,8 @@ def make_structure(name):
     open(os.path.join(f'{name}',f'{name}.in'), 'w').close()
 
   # Check if output file exists for the given name if not make it. 
-  if not  os.path.exists(os.path.join(basedir, os.path.join(f'{name}', f'{name}.out'))):
-    open(os.path.join(f'{name}', f'{name}.out'), 'w').close()
+  if not  os.path.exists(os.path.join(basedir, os.path.join(f'{name}', f'{name}.op'))):
+    open(os.path.join(f'{name}', f'{name}.op'), 'w').close()
 
 
 def fetch_tests(contest_name):
@@ -39,10 +39,10 @@ def fetch_tests(contest_name):
         with open(os.path.join(f'{file_name}' , f'{file_name}.in'), 'a') as f:
           f.write(i)
 
-      # Add outputs to .out files
+      # Add outputs to .op files
       for t in test.findAll("div", attrs={"class":"output"}):
         o = t.pre.text
-        with open(os.path.join(f'{file_name}' , f'{file_name}.out'), 'a') as f:
+        with open(os.path.join(f'{file_name}' , f'{file_name}.op'), 'a') as f:
           f.write(o)
 
   # In case of any error with scraping, display warning.

--- a/codemon/CodemonFetch.py
+++ b/codemon/CodemonFetch.py
@@ -1,8 +1,10 @@
 import requests
 import os
+from tqdm import tqdm
 from bs4 import BeautifulSoup as beSo
 import itertools
 from clint.textui import colored
+from codemon.CodemonMeta import get_filename
 
 def make_structure(name):
   basedir = os.getcwd()
@@ -25,9 +27,9 @@ def fetch_tests(contest_name):
     load_page = requests.get(f"https://codeforces.com/contest/{contest_name}/problems")
     soup = beSo(load_page.content, 'html.parser')
     tests = soup.findAll("div", attrs={"class":"sample-tests"})
-    name_list = ['A', 'B', 'C', 'D', 'E', 'F']
-
-    for file_name, test in zip(name_list, tests):
+    file_list = list(map(lambda x: x.split('.')[0], get_filename(contest_name)))
+    for file_name, test in tqdm(zip(file_list, tests), unit="ticks", desc="Fetching Sample test cases", 
+                                total=len(tests)):
       # Make the neccesary folders and files for each source file if not present.
       make_structure(file_name)
 

--- a/codemon/CodemonFetch.py
+++ b/codemon/CodemonFetch.py
@@ -1,30 +1,30 @@
 import requests
 import os
-from tqdm import tqdm
-from bs4 import BeautifulSoup as beSo
 import itertools
+from bs4 import BeautifulSoup as beSo
 from clint.textui import colored
 from codemon.CodemonMeta import get_filename
 
-def make_structure(name):
-  basedir = os.getcwd()
+def make_structure(name, contestName):
+  basedir = os.path.join(os.getcwd(), contestName)
 
   # Check if the question folder exists for the name passed if not make it.
   if not  os.path.exists(os.path.join(basedir, f'{name}')):
     os.makedirs(os.path.join(basedir, f'{name}'))
 
   # Check if input file exists for the given name if not make it. 
-  if not  os.path.exists(os.path.join(basedir, os.path.join(f'{name}',f'{name}.in'))):
-    open(os.path.join(f'{name}',f'{name}.in'), 'w').close()
+  if not os.path.exists(os.path.join(basedir, f'{name}',f'{name}.in')):
+    open(os.path.join(basedir, f'{name}',f'{name}.in'), 'w').close()
 
   # Check if output file exists for the given name if not make it. 
-  if not  os.path.exists(os.path.join(basedir, os.path.join(f'{name}', f'{name}.op'))):
-    open(os.path.join(f'{name}', f'{name}.op'), 'w').close()
+  if not os.path.exists(os.path.join(basedir, f'{name}', f'{name}.op')):
+    open(os.path.join(basedir, f'{name}', f'{name}.op'), 'w').close()
 
 
-def fetch_tests(contest_name):
+def fetch_tests(file_list, contestName):
   try:
-    load_page = requests.get(f"https://codeforces.com/contest/{contest_name}/problems")
+    basedir = os.path.join(os.getcwd(), contestName)
+    load_page = requests.get(f"https://codeforces.com/contest/{contestName}/problems")
     soup = beSo(load_page.content, 'html.parser')
     tests = soup.findAll("div", attrs={"class":"sample-tests"})
 
@@ -32,23 +32,21 @@ def fetch_tests(contest_name):
       print(colored.red("Wrong contest number provided"))
 
     else:
-      # Get the file names to scrape test cases for.
-      file_list = list(map(lambda x: x.split('.')[0], get_filename(contest_name)))
-      for file_name, test in tqdm(zip(file_list, tests), unit="ticks", desc="Fetching Sample test cases", 
-                                  total=len(tests)):
+      print(colored.green("Fetching sample test cases"))
+      for file_name, test in zip(file_list, tests):
         # Make the neccesary folders and files for each source file if not present.
-        make_structure(file_name)
+        make_structure(file_name, contestName)
 
         # Add  inputs to .in files
         for t in test.findAll("div", attrs={"class":"input"}):
           i = t.pre.text
-          with open(os.path.join(f'{file_name}' , f'{file_name}.in'), 'a') as f:
+          with open(os.path.join(basedir, f'{file_name}' , f'{file_name}.in'), 'a') as f:
             f.write(i)
 
         # Add outputs to .op files
         for t in test.findAll("div", attrs={"class":"output"}):
           o = t.pre.text
-          with open(os.path.join(f'{file_name}' , f'{file_name}.op'), 'a') as f:
+          with open(os.path.join(basedir, f'{file_name}' , f'{file_name}.op'), 'a') as f:
             f.write(o)
 
   # In case of any error with scraping, display warning.

--- a/codemon/CodemonFetch.py
+++ b/codemon/CodemonFetch.py
@@ -5,25 +5,25 @@ from bs4 import BeautifulSoup as beSo
 from clint.textui import colored
 from codemon.CodemonMeta import get_filename
 
-def make_structure(name, contestName):
-  basedir = os.path.join(os.getcwd(), contestName)
-
+def make_structure(name, *args):
+  basedir = os.path.join(os.getcwd(), args[0]) if args else os.getcwd()
+  path = os.path.join(basedir, f'{name}') if args else f'{name}'
   # Check if the question folder exists for the name passed if not make it.
   if not  os.path.exists(os.path.join(basedir, f'{name}')):
-    os.makedirs(os.path.join(basedir, f'{name}'))
+    os.makedirs(path)
 
   # Check if input file exists for the given name if not make it. 
   if not os.path.exists(os.path.join(basedir, f'{name}',f'{name}.in')):
-    open(os.path.join(basedir, f'{name}',f'{name}.in'), 'w').close()
+    open(os.path.join(path, f'{name}.in'), 'w').close()
 
   # Check if output file exists for the given name if not make it. 
   if not os.path.exists(os.path.join(basedir, f'{name}', f'{name}.op')):
-    open(os.path.join(basedir, f'{name}', f'{name}.op'), 'w').close()
+    open(os.path.join(path, f'{name}.op'), 'w').close()
 
 
 def fetch_tests(file_list, contestName):
   try:
-    basedir = os.path.join(os.getcwd(), contestName)
+    basedir = os.path.join(os.getcwd(), contestName) if not os.getcwd().split('/')[-1] == contestName else os.getcwd()
     load_page = requests.get(f"https://codeforces.com/contest/{contestName}/problems")
     soup = beSo(load_page.content, 'html.parser')
     tests = soup.findAll("div", attrs={"class":"sample-tests"})
@@ -32,10 +32,14 @@ def fetch_tests(file_list, contestName):
       print(colored.red("Wrong contest number provided"))
 
     else:
-      print(colored.green("Fetching sample test cases"))
+      print(colored.green("Fetching Inputs and Outputs"))
+
       for file_name, test in zip(file_list, tests):
         # Make the neccesary folders and files for each source file if not present.
-        make_structure(file_name, contestName)
+        if os.getcwd().split('/')[-1] == contestName:
+          make_structure(file_name)
+        else:
+          make_structure(file_name, contestName)
 
         # Add  inputs to .in files
         for t in test.findAll("div", attrs={"class":"input"}):
@@ -48,7 +52,7 @@ def fetch_tests(file_list, contestName):
           o = t.pre.text
           with open(os.path.join(basedir, f'{file_name}' , f'{file_name}.op'), 'a') as f:
             f.write(o)
-
+      print(colored.yellow("Inputs and Outputs added"))
   # In case of any error with scraping, display warning.
   except:
     print(colored.red("There was some error fetching the tests !!"))

--- a/codemon/CodemonHelp.py
+++ b/codemon/CodemonHelp.py
@@ -7,6 +7,8 @@ def showHelp():
   print("codemon - - - - - - - - - - - - - - -  displays this message")
   print("codemon --help - - - - - - - - - - - - shows help")
   print("codemon init <contestName> - - - - - - initialises a contest")
+  print("codemon fetch <contestName> - - - - fetches all the sample test cases for the contest name provided")
+  print("codemon fetch  - - - - - - - - - - - extracts contest name from contest directory name and fetches all sample test cases ")
   print("codemon init -n <file> - - - - - - - - creates file with given name")
   print("codemon listen - - - - - - - - - - - - compiles and gives output")
   print("codemon practice <dirName> - - - - - - Starts a practice session")

--- a/codemon/CodemonHelp.py
+++ b/codemon/CodemonHelp.py
@@ -10,3 +10,5 @@ def showHelp():
   print("codemon init -n <file> - - - - - - - - creates file with given name")
   print("codemon listen - - - - - - - - - - - - compiles and gives output")
   print("codemon practice <dirName> - - - - - - Starts a practice session")
+  print("codemon practice <dirName> - - - - - - Starts a practice session")
+  print("codemon reg - - - - - - - - - - - - -  Creates a file with all your details")

--- a/codemon/CodemonHelp.py
+++ b/codemon/CodemonHelp.py
@@ -9,6 +9,5 @@ def showHelp():
   print("codemon init <contestName> - - - - - - initialises a contest")
   print("codemon init -n <file> - - - - - - - - creates file with given name")
   print("codemon listen - - - - - - - - - - - - compiles and gives output")
+  print("codemon reg - - - - - - - - - - - - -  Register user details")
   print("codemon practice <dirName> - - - - - - Starts a practice session")
-  print("codemon practice <dirName> - - - - - - Starts a practice session")
-  print("codemon reg - - - - - - - - - - - - -  Creates a file with all your details")

--- a/codemon/CodemonInit.py
+++ b/codemon/CodemonInit.py
@@ -1,26 +1,43 @@
 import os
 from clint.textui import colored
-from codemon.CodemonMeta import template_cpp
+from codemon.CodemonMeta import Templates
 
 def write_to_file(filename, text, contestName=None):
-  full_filename = os.path.join(os.getcwd(), filename)
-  if contestName is not None:
-    full_filename = os.path.join(os.getcwd(), contestName, filename)
+  full_filename = os.path.join(os.getcwd(), os.path.join(contestName, filename.split('.')[0]), filename)
   with open(full_filename, 'w+') as f:
     f.write(text)
+  open(os.path.join(os.getcwd(),contestName, filename.split('.')[0], f"{filename.split('.')[0]}.in"), 'w').close()
+  open(os.path.join(os.getcwd(),contestName, filename.split('.')[0], f"{filename.split('.')[0]}.op"), 'w').close()
 
-def init(contestName,fileNames):
+def init(contestName,fileNames, init_flags):
   # create a directory with contest name
   try:
-    print(colored.green('Make some files and folders for ' + colored.magenta(contestName)))
+    print(colored.green(f'Creating directory for {contestName}...'))
     os.makedirs(os.path.join(os.getcwd(), contestName))
+    for f in fileNames:
+      os.makedirs(os.path.join(os.getcwd(), contestName, f))
   except OSError: 
     print("Failed! This directory cannot be created.")
   else:
-    print(colored.yellow('Directory is made'))
-      # create files for contest (should be 6 cpp files)
-    for files in range(len(fileNames)):
-      write_to_file(fileNames[files], template_cpp(), contestName)
-    # create input file
-    write_to_file('input.txt', '', contestName)
-    print(colored.cyan('Files have been created'))
+    print(colored.yellow('Contest directory made !!'))
+
+    templates, ext, use_template = Templates(), None, None
+
+    if init_flags["is_py"]:
+        ext, use_template = "py", templates.get_custom_template("py") or templates.default_py()
+
+    elif init_flags["is_java"]:
+        ext, use_template = "java", templates.get_custom_template("java") or templates.default_java()
+
+    elif init_flags["is_cpp"]:
+        ext, use_template = "cpp", templates.get_custom_template("cpp") or templates.default_cpp()
+
+    open(os.path.join(os.getcwd(), contestName, f"test_case"), 'w').close()
+    open(os.path.join(os.getcwd(), contestName, f"test_case.{ext}"), 'w').close()
+    for files in fileNames:
+      write_to_file(f"{files}.{ext}", use_template, contestName)
+
+def init_single_file(filename, template='\n'):
+  full_filename = os.path.join(os.getcwd(), filename)
+  with open(full_filename, 'w+') as f:
+    f.write(template)

--- a/codemon/CodemonInit.py
+++ b/codemon/CodemonInit.py
@@ -19,25 +19,29 @@ def init(contestName,fileNames, init_flags):
   except OSError:
     print("Failed! This directory cannot be created.")
   else:
-    print(colored.yellow('Directories made.'))
-
+    print(colored.yellow('Directories are made.'))
     templates, ext, use_template = Templates(), None, None
-
     if init_flags["is_py"]:
         ext, use_template = "py", templates.get_custom_template("py") or templates.default_py()
-
     elif init_flags["is_java"]:
         ext, use_template = "java", templates.get_custom_template("java") or templates.default_java()
-
     elif init_flags["is_cpp"]:
         ext, use_template = "cpp", templates.get_custom_template("cpp") or templates.default_cpp()
-
     open(os.path.join(os.getcwd(), contestName, f"test_case"), 'w').close()
     open(os.path.join(os.getcwd(), contestName, f"test_case.{ext}"), 'w').close()
     for files in fileNames:
       write_to_file(f"{files}.{ext}", use_template, contestName)
 
-def init_single_file(filename, template='\n'):
-  full_filename = os.path.join(os.getcwd(), filename)
+def init_single_file(filename, init_flags):
+  templates, ext, use_template = Templates(), None, None
+  if init_flags["is_py"]:
+    ext, use_template = "py", templates.get_custom_template("py") or templates.default_py()
+  elif init_flags["is_java"]:
+    ext, use_template = "java", templates.get_custom_template("java") or templates.default_java()
+  elif init_flags["is_cpp"]:
+    ext, use_template = "cpp", templates.get_custom_template("cpp") or templates.default_cpp()
+  full_filename = os.path.join(os.getcwd(), f"{filename}.{ext}")
+  print("Making single file")
   with open(full_filename, 'w+') as f:
-    f.write(template)
+    f.write(use_template)
+  print(colored.yellow(f"Created {filename}.{ext}"))

--- a/codemon/CodemonInit.py
+++ b/codemon/CodemonInit.py
@@ -12,14 +12,14 @@ def write_to_file(filename, text, contestName=None):
 def init(contestName,fileNames, init_flags):
   # create a directory with contest name
   try:
-    print(colored.green(f'Creating directory for {contestName}...'))
+    print(colored.green(f'Creating directories for {contestName}'))
     os.makedirs(os.path.join(os.getcwd(), contestName))
     for f in fileNames:
       os.makedirs(os.path.join(os.getcwd(), contestName, f))
   except OSError: 
     print("Failed! This directory cannot be created.")
   else:
-    print(colored.yellow('Contest directory made !!'))
+    print(colored.yellow('Directories made.'))
 
     templates, ext, use_template = Templates(), None, None
 

--- a/codemon/CodemonInit.py
+++ b/codemon/CodemonInit.py
@@ -14,7 +14,7 @@ def init(contestName,fileNames):
   try:
     print(colored.green('Make some files and folders for ' + colored.magenta(contestName)))
     os.makedirs(os.path.join(os.getcwd(), contestName))
-  except OSError: 
+  except OSError:
     print("Failed! This directory cannot be created.")
   else:
     print(colored.yellow('Directory is made'))

--- a/codemon/CodemonListen.py
+++ b/codemon/CodemonListen.py
@@ -1,8 +1,8 @@
 import os
-from pathlib import Path
 import subprocess
 import sys
 import time
+from pathlib import Path
 from clint.textui import colored
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer

--- a/codemon/CodemonListen.py
+++ b/codemon/CodemonListen.py
@@ -35,14 +35,14 @@ def listen():
 def isModified(event):
   filename = os.path.basename(event.src_path)
   foldername = os.path.basename(os.getcwd())
-  if filename != foldername and filename != "prog" and filename != "input.txt": 
+  if filename != foldername and filename != "prog" and filename != "test_case": 
     print(colored.yellow('\nChange made at '+ filename))
     print(colored.cyan('\nCompiling '+ filename))
     compile_and_run(filename)
 
 def compile_and_run(filename):
   # Store full file paths
-  full_filename = os.path.join(os.getcwd(), filename)
+  full_filename = os.path.join(os.getcwd(), filename.split('.')[0], filename)
   full_output_filename = os.path.join(os.getcwd(), 'prog')
   full_input_filename = os.path.join(os.getcwd(), 'test_case')
 

--- a/codemon/CodemonListen.py
+++ b/codemon/CodemonListen.py
@@ -44,7 +44,7 @@ def compile_and_run(filename):
   # Store full file paths
   full_filename = os.path.join(os.getcwd(), filename)
   full_output_filename = os.path.join(os.getcwd(), 'prog')
-  full_input_filename = os.path.join(os.getcwd(), 'input.txt')
+  full_input_filename = os.path.join(os.getcwd(), 'test_case')
 
   # Check if required files exist
   if not Path(full_filename).is_file():
@@ -66,7 +66,7 @@ def compile_and_run(filename):
   with open(full_input_filename, 'r+', encoding='utf-8') as infile:
     input_text = infile.read()
   if len(input_text) > 0 and not input_text.isspace():
-    print(colored.yellow('Taking input from input.txt.'))
+    print(colored.yellow('Taking input from test_case file.'))
     execution_child_process.stdin.write(input_text.encode(encoding='utf-8'))
   else:
     print(colored.yellow('Skipped fetching inputs as input file is empty.'))

--- a/codemon/CodemonMeta.py
+++ b/codemon/CodemonMeta.py
@@ -1,17 +1,20 @@
 import re
-from tqdm import tqdm
+import os
 from clint.textui import colored
 from datetime import datetime
 import requests
 from bs4 import BeautifulSoup as beSo
 
-def template_cpp():
-  # get the current time
-  now = datetime.now()
-  # the template for initial code
-  template = """/*
-  author: @ankingcodes
-  created: %s
+class Templates:
+
+  def default_cpp(self):
+    # get the current time
+    now = datetime.now()
+    # the template for initial code
+    template ="""
+/*
+ author: @ankingcodes
+ created: %s
 */
 #include<bits/stdc++.h>
 #include<algorithm>
@@ -21,14 +24,42 @@ using namespace std;
 #define MOD 1000000000
 
 int main(){
-  ios_base::sync_with_stdio(false);
-  cin.tie(NULL);
-  ll t;
-  return 0;
+ios_base::sync_with_stdio(false);
+cin.tie(NULL);
+ll t;
+return 0;
 }
-""" % (now)
+  """ % (now)
 
-  return template
+    return template
+
+  def default_py(self):
+    now = datetime.now()
+    template="""
+# author: @ankingcodes
+# created: %s
+# Write your code here
+   """ % (now)
+    return template
+
+  def default_java(self):
+    now = datetime.now()
+    template ="""
+// author: @ankingcodes
+// created: %s
+// Write your code here
+""" % (now)
+    return template
+
+  def get_custom_template(self, ext):
+    template = None
+    home = os.path.expanduser("~")
+    if(os.path.exists(os.path.join(home, ".codemon"))):
+      for file in os.listdir(os.path.join(home, ".codemon")):
+        if(file.split('.')[-1] == ext):
+          with open(os.path.join(home, ".codemon", file), 'r') as f:
+            template = f.read()
+    return template
 
 
 def get_filename(contesName):
@@ -36,22 +67,22 @@ def get_filename(contesName):
   contest_number = ''.join(re.findall(r'\d+', contesName))
   # In case contest number is not there, initialize a generic A, B, C, D, E, F
   if(not len(contest_number)):
-    fileNames = ['A.cpp','B.cpp','C.cpp','D.cpp','E.cpp','F.cpp']
+    fileNames = ['A','B','C','D','E','F', 'G']
   else:
     page = requests.get(f"https://codeforces.com/contest/{contest_number}/problems")
     soup = beSo(page.content, 'html.parser')
     titles = soup.findAll("div", attrs={"class":"title"})
     if titles[0].a:
       # In case contest number is wrong, initialize a generic A, B, C, D, E, F
-      fileNames = ['A.cpp','B.cpp','C.cpp','D.cpp','E.cpp','F.cpp']
+      fileNames = ['A','B','C','D','E','F','G']
     else:
       # Scrape Codeforces problem page and get the exact problem names
       for t in titles:
         if '.' in t.text:
-          fileNames.append(f"{t.text.split('.')[0]}.cpp")
+          fileNames.append(f"{t.text.split('.')[0]}")
 
   return fileNames
 
 def get_practice_files():
-  practiceFiles = ['A.cpp','B.cpp','C.cpp']
+  practiceFiles = ['A','B','C']
   return practiceFiles

--- a/codemon/CodemonMeta.py
+++ b/codemon/CodemonMeta.py
@@ -1,8 +1,8 @@
 import re
 import os
+import requests
 from clint.textui import colored
 from datetime import datetime
-import requests
 from bs4 import BeautifulSoup as beSo
 
 class Templates:
@@ -62,25 +62,28 @@ int main() {
     return template
 
 
-def get_filename(contesName):
+def get_filename(contestName):
   fileNames = []
-  contest_number = ''.join(re.findall(r'\d+', contesName))
+  contest_number = ''.join(re.findall(r'\d+', contestName))
   # In case contest number is not there, initialize a generic A, B, C, D, E, F
   if(not len(contest_number)):
     fileNames = ['A','B','C','D','E','F', 'G']
   else:
-    page = requests.get(f"https://codeforces.com/contest/{contest_number}/problems")
-    soup = beSo(page.content, 'html.parser')
-    titles = soup.findAll("div", attrs={"class":"title"})
-    if titles[0].a:
-      # In case contest number is wrong, initialize a generic A, B, C, D, E, F
-      fileNames = ['A','B','C','D','E','F','G']
-    else:
-      # Scrape Codeforces problem page and get the exact problem names
-      for t in titles:
-        if '.' in t.text:
-          fileNames.append(f"{t.text.split('.')[0]}")
-
+    try:
+      page = requests.get(f"https://codeforces.com/contest/{contest_number}/problems")
+      soup = beSo(page.content, 'html.parser')
+      titles = soup.findAll("div", attrs={"class":"title"})
+      if titles[0].a:
+        # In case contest number is wrong, initialize a generic A, B, C, D, E, F
+        fileNames = ['A','B','C','D','E','F','G']
+      else:
+        # Scrape Codeforces problem page and get the exact problem names
+        for t in titles:
+          if '.' in t.text:
+            fileNames.append(f"{t.text.split('.')[0]}")
+    # In case of an error initialize default directory.
+    except:
+      fileNames = ['A','B','C','D','E','F', 'G']
   return fileNames
 
 def get_practice_files():

--- a/codemon/CodemonMeta.py
+++ b/codemon/CodemonMeta.py
@@ -1,4 +1,5 @@
 import re
+from tqdm import tqdm
 from clint.textui import colored
 from datetime import datetime
 import requests

--- a/codemon/CodemonMeta.py
+++ b/codemon/CodemonMeta.py
@@ -1,5 +1,8 @@
+import re
 from clint.textui import colored
 from datetime import datetime
+import requests
+from bs4 import BeautifulSoup as beSo
 
 def template_cpp():
   # get the current time
@@ -27,8 +30,25 @@ int main(){
   return template
 
 
-def get_filename():
-  fileNames = ['A.cpp','B.cpp','C.cpp','D.cpp','E.cpp','F.cpp']
+def get_filename(contesName):
+  fileNames = []
+  contest_number = ''.join(re.findall(r'\d+', contesName))
+  # In case contest number is not there, initialize a generic A, B, C, D, E, F
+  if(not len(contest_number)):
+    fileNames = ['A.cpp','B.cpp','C.cpp','D.cpp','E.cpp','F.cpp']
+  else:
+    page = requests.get(f"https://codeforces.com/contest/{contest_number}/problems")
+    soup = beSo(page.content, 'html.parser')
+    titles = soup.findAll("div", attrs={"class":"title"})
+    if titles[0].a:
+      # In case contest number is wrong, initialize a generic A, B, C, D, E, F
+      fileNames = ['A.cpp','B.cpp','C.cpp','D.cpp','E.cpp','F.cpp']
+    else:
+      # Scrape Codeforces problem page and get the exact problem names
+      for t in titles:
+        if '.' in t.text:
+          fileNames.append(f"{t.text.split('.')[0]}.cpp")
+
   return fileNames
 
 def get_practice_files():

--- a/codemon/CodemonMeta.py
+++ b/codemon/CodemonMeta.py
@@ -23,11 +23,11 @@ using namespace std;
 #define ll long long
 #define MOD 1000000000
 
-int main(){
-ios_base::sync_with_stdio(false);
-cin.tie(NULL);
-ll t;
-return 0;
+int main() {
+  ios_base::sync_with_stdio(false);
+  cin.tie(NULL);
+  ll t;
+  return 0;
 }
   """ % (now)
 

--- a/codemon/CodemonParse.py
+++ b/codemon/CodemonParse.py
@@ -1,4 +1,5 @@
 # Parse all command line arguments and options.
+import re
 
 
 class Parser:
@@ -10,10 +11,9 @@ class Parser:
     self.to_init, self.init_flags = False, { "is_single": False, "is_cpp":True,
                                              "is_java":False, "is_py":False,
                                              "to_fetch":False }
-    self.single_file_name = ""
-    self.contest_name = ""
     self.to_fetch = False
     self.Reg = False
+    self.name = ""
 
   def parse(self, arg_list):
     countArg = 0
@@ -22,49 +22,41 @@ class Parser:
     if len(arg_list) == 0:
       self.help = True
 
-    # Commands with one argument can be added here.
-    elif len(arg_list) == 1:
-      if arg_list[countArg] == "listen":
-        self.to_listen = True
-      elif arg_list[countArg] == "practice":
-        self.to_practice = True
-      elif arg_list[countArg] == "--help":
+    # Extract all flags/option
+    flags = list(map(lambda x: x.strip(), re.findall('.\-.\w*', " " + ' '.join(arg_list))))
+
+    # Extract all non flag arguments
+    arguments = [i for i in arg_list if i not in flags]
+
+    for fl in flags:
+      if fl == '-py':
+        self.init_flags["is_py"] = True
+      elif fl == '-java':
+        self.init_flags["is_java"] = True
+      elif fl == '-n':
+        self.init_flags["is_single"] = True
+      elif fl in ("-f", "--fetch"):
+        self.init_flags["to_fetch"] = True
+      elif fl == "--help":
         self.help = True
-      elif arg_list[countArg] == "fetch":
-        self.to_fetch = True
-      elif arg_list[countArg] == "reg":
+
+    for a in arguments:
+
+      if a == "listen":
+        self.to_listen = True
+
+      elif a == "init":
+        self.to_init = True
+
+      elif a == "reg":
         self.Reg = True
 
-    # Commands with several arguments, options or flags can be added here.
-    else:
-      if(arg_list[countArg] == "init"):
-        self.to_init = True
-        if(arg_list[countArg+1] == "-n"):
-          self.init_flags["is_single"] = True
-          self.single_file_name += arg_list[countArg + 2]
-          if len(arg_list[2:]) == 2:
-            if(arg_list[countArg+3] == "-py"):
-              self.init_flags["is_py"] = True
-            elif(arg_list[countArg+3] == "-java"):
-              self.init_flags["is_java"] = True
+      elif a == "practice":
+        self.to_practice = True
 
-        elif arg_list[countArg+1] in ("-f", "--fetch"):
-          self.contest_name += arg_list[countArg + 2]
-          self.init_flags["to_fetch"] = True
-          if len(arg_list[2:]) == 2:
-            if(arg_list[countArg+3] == "-py"):
-              self.init_flags["is_py"] = True
-            elif(arg_list[countArg+3] == "-java"):
-              self.init_flags["is_java"] = True
-
-        else:
-          self.contest_name += arg_list[countArg+1]
-          if len(arg_list[1:]) == 2:
-            if(arg_list[countArg+2] == "-py"):
-              self.init_flags["is_py"] = True
-            elif(arg_list[countArg+2] == "-java"):
-              self.init_flags["is_java"] = True
-
-      elif arg_list[countArg] == "fetch":
+      elif a == "fetch":
         self.to_fetch = True
-        self.contest_name += arg_list[countArg + 1]
+
+      else:
+        self.name += a
+

--- a/codemon/CodemonParse.py
+++ b/codemon/CodemonParse.py
@@ -1,7 +1,6 @@
 # Parse all command line arguments and options.
 import re
 
-
 class Parser:
 
   def __init__(self):
@@ -16,22 +15,27 @@ class Parser:
     self.name = ""
 
   def parse(self, arg_list):
-    countArg = 0
 
     # No arguments provided
     if len(arg_list) == 0:
       self.help = True
-
     # Extract all flags/option
     flags = list(map(lambda x: x.strip(), re.findall('.\-.\w*', " " + ' '.join(arg_list))))
-
     # Extract all non flag arguments
     arguments = [i for i in arg_list if i not in flags]
 
     for fl in flags:
       if fl == '-py':
+        # error check: if two language flags present at the same time, show help.
+        if "-java" in flags or "-cpp" in flags:
+          self.help = True
+          break
         self.init_flags["is_py"] = True
       elif fl == '-java':
+        # error check: if two language flags present at the same time, show help.
+        if "-py" in flags or "-cpp" in flags:
+          self.help = True
+          break
         self.init_flags["is_java"] = True
       elif fl == '-n':
         self.init_flags["is_single"] = True
@@ -41,14 +45,21 @@ class Parser:
         self.help = True
 
     for a in arguments:
-
+      # error check: if any other argument provided with listen show help.
       if a == "listen":
+        if(len(arguments) > 1):
+          self.help = True
+          break
         self.to_listen = True
 
       elif a == "init":
         self.to_init = True
 
+      # error check: if any other argument provided with reg show help.
       elif a == "reg":
+        if(len(arguments) > 1):
+          self.help = True
+          break
         self.Reg = True
 
       elif a == "practice":

--- a/codemon/CodemonParse.py
+++ b/codemon/CodemonParse.py
@@ -1,7 +1,7 @@
 # Parse all command line arguments and options.
 
 
-class Commands:
+class Parser:
 
   def __init__(self):
     self.to_listen = False
@@ -12,6 +12,7 @@ class Commands:
                                              "to_fetch":False }
     self.single_file_name = ""
     self.contest_name = ""
+    self.to_fetch = False
 
   def parse(self, arg_list):
     countArg = 0
@@ -28,6 +29,8 @@ class Commands:
         self.to_practice = True
       elif arg_list[countArg] == "--help":
         self.help = True
+      elif arg_list[countArg] == "fetch":
+        self.to_fetch = True
 
     # Commands with several arguments, options or flags can be added here.
     else:
@@ -41,6 +44,7 @@ class Commands:
               self.init_flags["is_py"] = True
             elif(arg_list[countArg+3] == "-java"):
               self.init_flags["is_java"] = True
+
         elif arg_list[countArg+1] in ("-f", "--fetch"):
           self.contest_name += arg_list[countArg + 2]
           self.init_flags["to_fetch"] = True
@@ -57,3 +61,7 @@ class Commands:
               self.init_flags["is_py"] = True
             elif(arg_list[countArg+2] == "-java"):
               self.init_flags["is_java"] = True
+
+      elif arg_list[countArg] == "fetch":
+        self.to_fetch = True
+        self.contest_name += arg_list[countArg + 1]

--- a/codemon/CodemonParse.py
+++ b/codemon/CodemonParse.py
@@ -1,0 +1,49 @@
+# Parse all command line arguments and options.
+
+
+class Commands:
+  def __init__(self):
+    self.to_listen = False
+    self.help = False
+    self.to_practice = False
+    self.to_init, self.init_flags = False, { "is_single": False, "is_cpp":True,
+                                             "is_java":False, "is_py":False,
+                                             "to_fetch":False }
+    self.single_file_name = ""
+    self.contest_name = ""
+
+  def parse(self, arg_list):
+    countArg = 0
+
+    # No arguments provided
+    if len(arg_list) == 0:
+      self.help = True
+
+    # One argument commands.
+    elif len(arg_list) == 1:
+      if arg_list[countArg] == "listen":
+        self.to_listen = True
+      elif arg_list[countArg] == "practice":
+        self.to_practice = True
+      elif arg_list[countArg] == "--help":
+        self.help = True
+
+    # Commands with several arguments, options or flags.
+    else:
+      if(arg_list[countArg] == "init"):
+        self.to_init = True
+        if(arg_list[countArg+1] == "-n"):
+          self.init_flags["is_single"] = True
+          self.single_file_name += arg_list[countArg + 2]
+          if len(arg_list[2:]) == 2:
+            if(arg_list[countArg+3] == "-py"):
+              self.init_flags["is_py"] = True
+            elif(arg_list[countArg+3] == "-java"):
+              self.init_flags["is_java"] = True
+        else:
+          self.contest_name += arg_list[countArg+1]
+          if len(arg_list[1:]) == 2:
+            if(arg_list[countArg+2] == "-py"):
+              self.init_flags["is_py"] = True
+            elif(arg_list[countArg+2] == "-java"):
+              self.init_flags["is_java"] = True

--- a/codemon/CodemonParse.py
+++ b/codemon/CodemonParse.py
@@ -2,6 +2,7 @@
 
 
 class Commands:
+
   def __init__(self):
     self.to_listen = False
     self.help = False
@@ -19,7 +20,7 @@ class Commands:
     if len(arg_list) == 0:
       self.help = True
 
-    # One argument commands.
+    # Commands with one argument can be added here.
     elif len(arg_list) == 1:
       if arg_list[countArg] == "listen":
         self.to_listen = True
@@ -28,7 +29,7 @@ class Commands:
       elif arg_list[countArg] == "--help":
         self.help = True
 
-    # Commands with several arguments, options or flags.
+    # Commands with several arguments, options or flags can be added here.
     else:
       if(arg_list[countArg] == "init"):
         self.to_init = True
@@ -40,6 +41,15 @@ class Commands:
               self.init_flags["is_py"] = True
             elif(arg_list[countArg+3] == "-java"):
               self.init_flags["is_java"] = True
+        elif arg_list[countArg+1] in ("-f", "--fetch"):
+          self.contest_name += arg_list[countArg + 2]
+          self.init_flags["to_fetch"] = True
+          if len(arg_list[2:]) == 2:
+            if(arg_list[countArg+3] == "-py"):
+              self.init_flags["is_py"] = True
+            elif(arg_list[countArg+3] == "-java"):
+              self.init_flags["is_java"] = True
+
         else:
           self.contest_name += arg_list[countArg+1]
           if len(arg_list[1:]) == 2:

--- a/codemon/CodemonReg.py
+++ b/codemon/CodemonReg.py
@@ -22,9 +22,9 @@ def codemonReg():
     print("\nPlease enter the following data.\nYour sensitive information is collected for making your life easier while using Codemon.\nIt will be stored on your local machine.\nIt won't be stored or used by Codemon developers for any purpose. ")
     name = input("\nEnter Name : ")
     codeforces_username = input("Codeforces username (without @) : ")
-    codeforces_password = stdiomask.getpass(prompt="Codeforces password (not shown): ")
+    codeforces_password = stdiomask.getpass(prompt="Codeforces password : ")
     github_username = input("Github username (without @) : ")
-    github_password = stdiomask.getpass(prompt="GitHub Password (not shown): ")
+    github_password = stdiomask.getpass(prompt="GitHub Password : ")
     dataDict = {}
     dataDict["name"] = name
     dataDict["codeforces_username"] = codeforces_username

--- a/codemon/CodemonReg.py
+++ b/codemon/CodemonReg.py
@@ -6,22 +6,31 @@ from clint.textui import colored
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 def codemonReg():
-    print(ROOT_DIR)
-    path = os.path.join(ROOT_DIR, "codemon")
+    #print(ROOT_DIR)
+    prefix = '.' if os.name != 'nt' else ''
+    file_name = prefix + "codemon"
+    path = os.path.join(ROOT_DIR, file_name)
     if not os.path.exists(path):
         os.makedirs(path)
-        FILE_ATTRIBUTE_HIDDEN = 0x02
-        ret = ctypes.windll.kernel32.SetFileAttributesW(path, FILE_ATTRIBUTE_HIDDEN)
-    meta = ""
-    name = input("Name : ")
-    cf_user = input("CF Username : ")
-    cf_pass = input("CF Password : ")
-    git_user = input("GitHub Username : ")
-    git_pass = input("GitHub Password : ")
-    meta += name + "\n" + cf_user + "\n" + cf_pass + "\n" + git_user + "\n" + git_pass
-    full_filename = os.path.join(ROOT_DIR, "codemon", "meta.txt")
+        if os.name == 'nt':
+            FILE_ATTRIBUTE_HIDDEN = 0x02
+            ret = ctypes.windll.kernel32.SetFileAttributesW(path, FILE_ATTRIBUTE_HIDDEN)
+
+    print("Codemon User Registration")
+    print("\nPlease enter the following data. Your sensitive information is collected for making your life easier while using Codemon and will be stored on your local machine. It won't be stored or used by Codemon developers for any purpose. ")
+    name = input("\nEnter Name : ")
+    codeforces_username = input("Codeforces username (without @) : ")
+    codeforces_password = input("Codeforces password: ")
+    github_username = input("Github username: ")
+    github_password = input("GitHub Password : ")
+    meta = ('{\n', '  "name": "', name, '",\n', '  "codeforces username": "', codeforces_username, '",\n',
+            '  "codeforces password": "', codeforces_password, '",\n',
+            '  "github username": "', github_username, '",\n',
+            '  "github password": "', github_password, '",\n', '}\n')
+    jsondata = ''.join(meta)
+    full_filename = os.path.join(ROOT_DIR, file_name, "meta.txt")
     with open(full_filename, 'w+') as f:
-        f.write(meta)
+        f.write(jsondata)
 
 
 

--- a/codemon/CodemonReg.py
+++ b/codemon/CodemonReg.py
@@ -1,0 +1,28 @@
+import sys
+import os
+import ctypes
+from clint.textui import colored
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+def codemonReg():
+    print(ROOT_DIR)
+    path = os.path.join(ROOT_DIR, "codemon")
+    if not os.path.exists(path):
+        os.makedirs(path)
+        FILE_ATTRIBUTE_HIDDEN = 0x02
+        ret = ctypes.windll.kernel32.SetFileAttributesW(path, FILE_ATTRIBUTE_HIDDEN)
+    meta = ""
+    name = input("Name : ")
+    cf_user = input("CF Username : ")
+    cf_pass = input("CF Password : ")
+    git_user = input("GitHub Username : ")
+    git_pass = input("GitHub Password : ")
+    meta += name + "\n" + cf_user + "\n" + cf_pass + "\n" + git_user + "\n" + git_pass
+    full_filename = os.path.join(ROOT_DIR, "codemon", "meta.txt")
+    with open(full_filename, 'w+') as f:
+        f.write(meta)
+
+
+
+

--- a/codemon/CodemonReg.py
+++ b/codemon/CodemonReg.py
@@ -1,15 +1,16 @@
 import sys
 import os
 import ctypes
+import json
 from clint.textui import colored
+from os.path import expanduser
+from getpass import getpass
 
-ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+home = expanduser("~")
 
 def codemonReg():
-    #print(ROOT_DIR)
-    prefix = '.' if os.name != 'nt' else ''
-    file_name = prefix + "codemon"
-    path = os.path.join(ROOT_DIR, file_name)
+    file_name = ".codemon"
+    path = os.path.join(home, file_name)
     if not os.path.exists(path):
         os.makedirs(path)
         if os.name == 'nt':
@@ -17,20 +18,22 @@ def codemonReg():
             ret = ctypes.windll.kernel32.SetFileAttributesW(path, FILE_ATTRIBUTE_HIDDEN)
 
     print("Codemon User Registration")
-    print("\nPlease enter the following data. Your sensitive information is collected for making your life easier while using Codemon and will be stored on your local machine. It won't be stored or used by Codemon developers for any purpose. ")
+    print("\nPlease enter the following data.\nYour sensitive information is collected for making your life easier while using Codemon.\nIt will be stored on your local machine.\nIt won't be stored or used by Codemon developers for any purpose. ")
     name = input("\nEnter Name : ")
     codeforces_username = input("Codeforces username (without @) : ")
-    codeforces_password = input("Codeforces password: ")
-    github_username = input("Github username: ")
-    github_password = input("GitHub Password : ")
-    meta = ('{\n', '  "name": "', name, '",\n', '  "codeforces username": "', codeforces_username, '",\n',
-            '  "codeforces password": "', codeforces_password, '",\n',
-            '  "github username": "', github_username, '",\n',
-            '  "github password": "', github_password, '",\n', '}\n')
-    jsondata = ''.join(meta)
-    full_filename = os.path.join(ROOT_DIR, file_name, "meta.txt")
+    codeforces_password = getpass("Codeforces password (not shown): ")
+    github_username = input("Github username (without @) : ")
+    github_password = getpass("GitHub Password (not shown): ")
+    dataDict = {}
+    dataDict["name"] = name
+    dataDict["codeforces_username"] = codeforces_username
+    dataDict["codeforces_password"] = codeforces_password
+    dataDict["github_username"] = github_username
+    dataDict["github_password"] = github_password
+    dataJson = json.dumps(dataDict, indent=4)
+    full_filename = os.path.join(home, file_name, "meta.json")
     with open(full_filename, 'w+') as f:
-        f.write(jsondata)
+        f.write(dataJson)
 
 
 

--- a/codemon/CodemonReg.py
+++ b/codemon/CodemonReg.py
@@ -5,6 +5,7 @@ import json
 from clint.textui import colored
 from os.path import expanduser
 from getpass import getpass
+import stdiomask
 
 home = expanduser("~")
 
@@ -21,9 +22,9 @@ def codemonReg():
     print("\nPlease enter the following data.\nYour sensitive information is collected for making your life easier while using Codemon.\nIt will be stored on your local machine.\nIt won't be stored or used by Codemon developers for any purpose. ")
     name = input("\nEnter Name : ")
     codeforces_username = input("Codeforces username (without @) : ")
-    codeforces_password = getpass("Codeforces password (not shown): ")
+    codeforces_password = stdiomask.getpass(prompt="Codeforces password (not shown): ")
     github_username = input("Github username (without @) : ")
-    github_password = getpass("GitHub Password (not shown): ")
+    github_password = stdiomask.getpass(prompt="GitHub Password (not shown): ")
     dataDict = {}
     dataDict["name"] = name
     dataDict["codeforces_username"] = codeforces_username

--- a/codemon/codemon.py
+++ b/codemon/codemon.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/python3
 import sys
 import os
@@ -8,49 +9,35 @@ from codemon.CodemonListen import listen
 from codemon.CodemonInit import init
 from codemon.CodemonMeta import template_cpp,get_filename, get_practice_files
 from codemon.CodemonFetch import fetch_tests, make_structure
+from codemon.CodemonParse import Commands
 
 def main():
-  if len(sys.argv) < 2:
+  arg = Commands()
+  arg.parse(sys.argv[1:])
+
+  if arg.help:
     showHelp()
 
+  elif arg.to_listen:
+    listen()
+
+  elif arg.to_practice:
+    contestName = sys.argv[countArg]
+    practiceFiles = get_practice_files()
+    init(contestName, practiceFiles)
+
+  elif arg.to_init:
+    if arg.init_flags["is_single"]:
+      fileName = arg.single_file_name
+      template = template_cpp()
+      init_single_file(f'{fileName}.cpp', template)
+      print(colored.yellow(f'Created {fileName}.cpp'))
+    else:
+      contestName = arg.contest_name
+      fileNames = get_filename(contestName)
+      init(contestName, fileNames)
   else:
-    countArg = 0
-    for arg in sys.argv:
-      countArg+=1
-
-      if arg == "init":
-        if sys.argv[countArg] == '-n':
-          fileName = sys.argv[countArg+1]
-          template = template_cpp()
-          init_single_file(f'{fileName}.cpp', template)
-          print(colored.yellow(f'Created {fileName}.cpp'))
-          break
-
-        else:
-          contestName = sys.argv[countArg]
-          fileNames = get_filename(contestName)
-          init(contestName, fileNames)
-
-      elif arg == "listen":
-        listen()
-
-      elif arg == "practice":
-        contestName = sys.argv[countArg]
-        practiceFiles = get_practice_files()
-        init(contestName, practiceFiles)
-
-      elif arg == "--help":
-        showHelp()
-        break
-      elif arg == "fetch":
-        try:
-          # if User provides contest number as arguement.
-          fetch_tests(sys.argv[countArg])
-        except IndexError:
-          # Extract all numbers from current directory name.
-          contest_number = ''.join(re.findall(r'\d+', os.getcwd().split('/')[-1]))
-          fetch_tests(contest_number)
-
+    showHelp()
 
 def init_single_file(filename, template='\n'):
   full_filename = os.path.join(os.getcwd(), filename)

--- a/codemon/codemon.py
+++ b/codemon/codemon.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 import sys
 import os
+import re
 from clint.textui import colored
 from codemon.CodemonHelp import showHelp
 from codemon.CodemonListen import listen
@@ -41,6 +42,15 @@ def main():
       elif arg == "--help":
         showHelp()
         break
+      elif arg == "fetch":
+        try:
+          # if User provides contest number as arguement.
+          fetch_tests(sys.argv[countArg])
+        except IndexError:
+          # Extract all numbers from current directory name.
+          contest_number = ''.join(re.findall(r'\d+', os.getcwd().split('/')[-1]))
+          fetch_tests(contest_number)
+
 
 def init_single_file(filename, template='\n'):
   full_filename = os.path.join(os.getcwd(), filename)

--- a/codemon/codemon.py
+++ b/codemon/codemon.py
@@ -23,29 +23,27 @@ def main():
     listen()
 
   elif arg.to_practice:
-    contestName = sys.argv[countArg]
+    contestName = arg.name
     practiceFiles = get_practice_files()
-    init(contestName, practiceFiles)
+    init(contestName, practiceFiles, arg.init_flags)
 
   elif arg.to_init:
     if arg.init_flags["is_single"]:
-      fileName = arg.single_file_name
-      template = "\n"
-      init_single_file(f'{fileName}', template)
-      print(colored.yellow(f'Created {fileName}.cpp'))
+      fileName = arg.name
+      init_single_file(f'{fileName}', arg.init_flags)
     else:
-      contestName = arg.contest_name
+      contestName = arg.name
       fileNames = get_filename(contestName)
       init(contestName, fileNames, arg.init_flags)
       if arg.init_flags["to_fetch"]:
         fetch_tests(fileNames, contestName)
   elif arg.to_fetch:
-    if arg.contest_name == "":
+    if arg.name == "":
       contestName = ''.join(re.findall(r'\d+', os.getcwd().split('/')[-1]))
       fileNames = get_filename(contestName)
       fetch_tests(fileNames, contestName)
     else:
-      contestName = arg.contest_name
+      contestName = arg.name
       fileName = get_filename(contestName)
       fetch_tests(fileName, contestName)
   elif arg.Reg:

--- a/codemon/codemon.py
+++ b/codemon/codemon.py
@@ -5,6 +5,7 @@ from clint.textui import colored
 from codemon.CodemonHelp import showHelp
 from codemon.CodemonListen import listen
 from codemon.CodemonInit import init
+from codemon.CodemonReg import codemonReg
 from codemon.CodemonMeta import template_cpp,get_filename, get_practice_files
 
 def main():
@@ -39,6 +40,10 @@ def main():
 
       elif arg == "--help":
         showHelp()
+        break
+
+      elif arg == "reg":
+        codemonReg()
         break
 
 def init_single_file(filename, template='\n'):

--- a/codemon/codemon.py
+++ b/codemon/codemon.py
@@ -28,7 +28,7 @@ def main():
 
         else:
           contestName = sys.argv[countArg]
-          fileNames = get_filename()
+          fileNames = get_filename(contestName)
           init(contestName, fileNames)
 
       elif arg == "listen":

--- a/codemon/codemon.py
+++ b/codemon/codemon.py
@@ -9,10 +9,10 @@ from codemon.CodemonListen import listen
 from codemon.CodemonInit import init, init_single_file
 from codemon.CodemonMeta import get_filename, get_practice_files
 from codemon.CodemonFetch import fetch_tests, make_structure
-from codemon.CodemonParse import Commands
+from codemon.CodemonParse import Parser
 
 def main():
-  arg = Commands()
+  arg = Parser()
   arg.parse(sys.argv[1:])
 
   if arg.help:
@@ -38,6 +38,16 @@ def main():
       init(contestName, fileNames, arg.init_flags)
       if arg.init_flags["to_fetch"]:
         fetch_tests(fileNames, contestName)
+  elif arg.to_fetch:
+    if arg.contest_name == "":
+      contestName = ''.join(re.findall(r'\d+', os.getcwd().split('/')[-1]))
+      fileNames = get_filename(contestName)
+      fetch_tests(fileNames, contestName)
+    else:
+      contestName = arg.contest_name
+      fileName = get_filename(contestName)
+      fetch_tests(fileName, contestName)
+
   else:
     showHelp()
 

--- a/codemon/codemon.py
+++ b/codemon/codemon.py
@@ -5,6 +5,7 @@ from clint.textui import colored
 from codemon.CodemonHelp import showHelp
 from codemon.CodemonListen import listen
 from codemon.CodemonInit import init
+from codemon.CodemonFetch import fetch_tests, make_structure
 from codemon.CodemonMeta import template_cpp,get_filename,get_practice_files
 
 def main():
@@ -43,3 +44,22 @@ def main():
       elif arg == "--help":
         showHelp()
         break
+
+      elif arg == "fetch":
+        # In case user provided the contest name.
+        try:
+          fetch_tests(sys.argv[countArg])
+        # if not check if in contest directory
+        # then extract the contest name and fetch sample tests.
+        except IndexError:
+          # Directory after init should have 6 source files and one input file.
+
+          # check is a list that has the expected state of contest directory
+          check = ['A', 'B', 'C', 'D', 'E', 'F', 'input']
+
+          # current is a list that has the state of the current directory.
+          current = sorted(list(map(lambda x: x.split('.')[0], os.listdir())))
+          if current != check:
+            print(colored.red("Not in contest directory !!\nPlease navigate to the contest directory"))
+          else:
+            fetch_tests(os.getcwd().split('/')[-1])

--- a/codemon/codemon.py
+++ b/codemon/codemon.py
@@ -6,8 +6,8 @@ import re
 from clint.textui import colored
 from codemon.CodemonHelp import showHelp
 from codemon.CodemonListen import listen
-from codemon.CodemonInit import init
-from codemon.CodemonMeta import template_cpp,get_filename, get_practice_files
+from codemon.CodemonInit import init, init_single_file
+from codemon.CodemonMeta import get_filename, get_practice_files
 from codemon.CodemonFetch import fetch_tests, make_structure
 from codemon.CodemonParse import Commands
 
@@ -29,17 +29,15 @@ def main():
   elif arg.to_init:
     if arg.init_flags["is_single"]:
       fileName = arg.single_file_name
-      template = template_cpp()
-      init_single_file(f'{fileName}.cpp', template)
+      template = "\n"
+      init_single_file(f'{fileName}', template)
       print(colored.yellow(f'Created {fileName}.cpp'))
     else:
       contestName = arg.contest_name
       fileNames = get_filename(contestName)
-      init(contestName, fileNames)
+      init(contestName, fileNames, arg.init_flags)
+      if arg.init_flags["to_fetch"]:
+        fetch_tests(fileNames, contestName)
   else:
     showHelp()
 
-def init_single_file(filename, template='\n'):
-  full_filename = os.path.join(os.getcwd(), filename)
-  with open(full_filename, 'w+') as f:
-    f.write(template)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,9 @@ setup(
   packages=find_packages(),
   install_requires=[
     'watchdog',
-    'clint'
+    'clint',
+    'requests',
+    'bs4'
   ],
   entry_points={
     'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
     'watchdog',
     'clint',
     'requests',
-    'bs4'
+    'bs4',
+    'tqdm'
   ],
   entry_points={
     'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,7 @@ setup(
     'watchdog',
     'clint',
     'requests',
-    'bs4',
-    'tqdm'
+    'bs4'
   ],
   entry_points={
     'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
   install_requires=[
     'watchdog',
     'clint',
-    'stdiomask'
+    'stdiomask', 
     'requests',
     'bs4',
     'tqdm'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ setup(
   packages=find_packages(),
   install_requires=[
     'watchdog',
-    'clint'
+    'clint',
+    'stdiomask'
   ],
   entry_points={
     'console_scripts': [


### PR DESCRIPTION
Closes #17

#### Additions.

- `CodemonFetch` Module
  - Compatible with #12, #13 and #14 as the `make_structure` function in `CodemonFetch` module first checks if the necessary files and directories exist and then makes them if they don't. Once #12 #13 #14 are integrated into the project there would be no need to make any changes in this module as `make_structure`  function can then only as a safety check for the presence of Input and Output files.
  - `fetch_tests` function takes the contest name as argument and scrapes codeforces problem section to get the sample test cases and write them to input and output files (`A.in` and `A.op`  etc.) of respective problems.
  - if wrong contest name/number is provided, an error message is displayed.
- Dependencies
  - Added `requests` and `bs4` for scraping. 
  - Added `tqdm` for progress bar while fetching sample test cases.

#### Modifications
- `codemon.py`:
  - Added conditional to read fetch command. 
    ```py
        elif arg == "fetch":
        try:
          # if User provides contest number as arguement.
          fetch_tests(sys.argv[countArg])
        except IndexError:
          # Extract all numbers from current directory name.
          contest_number = ''.join(re.findall(r'\d+', os.getcwd().split('/')[-1]))
          fetch_tests(contest_number)
    ```
  - if user provides contest number as argument it will be simply passed to `fetch_tests` function. Otherwise there will be an
IndexError. In that case the user hasn't provided an argument. So, the contest number will be parsed from the current contest directory. Here, number of the contest is extracted using regex. Assumption is that the correct contest number should be present in the contest directory name. 
 
- `CodemonMeta` : 
  - A new way of extracting filenames was added to solve an inconsistency with scraping sample test cases. For example, contest number `1234` has problems `A, B1, B2, C, D, E, F`. So by the old way, sample test cases for problem B2 might get stored under the name of `C`. Or, in other cases where there are problems till `G` the sample test cases for the last problem will be missing.  
  - So to create a consistent interface for the user, file names will be extracted by scraping the contest page. Again, same assumption applies, the contest number should be present in the contest name provided by the user. If contest number is not there or if it is wrong, a generic `A, B, C, D, E, F` is used for filenames.

